### PR TITLE
[SCDO_4] Buffer the assembly like a outline

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -135,10 +135,6 @@ void makeLine(Polygom &polyShape, BoostLineString &bgLineStr) {
 	bg::read_wkt("LINESTRING(" + polyShape.shape + ")", bgLineStr);
 }
 
-void buildAssemblyLine() {
-
-}
-
 void buildAssemblyLine(Polygom &assembly, const double assemblygap, BoostMultiLineString multiCropperLs, const double croppergap, BoostMultipolygon &cropperMulLsBuffer, vector<BoostLineString> &bgDiff){
 	BoostMultiLineString assemblyMultLine;
 	BoostLineString assemblyLs;
@@ -230,7 +226,6 @@ int main()
 		mapper.add(bgAssembly);
 		mapper.add(multBGCropper);
 		mapper.add(cropperMulLsBuffer);
-
 
 		for (int i = 0; i < bgDiff.size(); ++i) {
 			if (bg::within(bgDiff[i], multBGCropper) == false) {


### PR DESCRIPTION
[SCDO_4](https://www.notion.so/SCDO_4-Buffer-the-assembly-like-a-outline-b51c4c165d01401191903f8d6257d0db)

buildAssemblyLine:
                    1. Buffer the assembly line
                    2. Buffer the cropper
                    3. silkscreen = Buffered_assembly_line - Buffered_cropper
                   